### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 RepoMap is a powerful tool designed to help, primarily LLMs, understand and navigate complex codebases. It functions both as a command-line application for on-demand analysis and as an MCP (Model Context Protocol) server, providing continuous repository mapping capabilities to other applications. By generating a "map" of the software repository, RepoMap highlights important files, code definitions, and their relationships. It leverages Tree-sitter for accurate code parsing and the PageRank algorithm to rank code elements by importance, ensuring that the most relevant information is always prioritized.
 
+<a href="https://glama.ai/mcp/servers/@pdavis68/RepoMapper">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pdavis68/RepoMapper/badge" alt="RepoMap MCP server" />
+</a>
 
 ## Table of Contents
 - [Aider](#aider)


### PR DESCRIPTION
This PR adds a badge for the [RepoMap](https://glama.ai/mcp/servers/@pdavis68/RepoMapper) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@pdavis68/RepoMapper">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pdavis68/RepoMapper/badge" alt="RepoMap MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.